### PR TITLE
modified etch to handle lists, added tests

### DIFF
--- a/desk/lib/etch.hoon
+++ b/desk/lib/etch.hoon
@@ -26,7 +26,7 @@
     ?~  hed  tal
     ?:  &(?=([%s @t] hed) ?=([%s @t] tal))
       [%a hed tal ~]
-    ?:  &(?=([%s @t] hed) !?=([%s @t] tal))
+    ?:  &(?=([%s @t] hed) !?=([%s @t] tal) !?=([%a *] tal) !=(~ tal))
       [%a hed tal ~]
     ?:  &(?=([%a *] hed) ?=([%a *] tal))
       [%a (weld p.hed p.tal)]

--- a/desk/lib/test.hoon
+++ b/desk/lib/test.hoon
@@ -1,0 +1,82 @@
+::  testing utilities meant to be directly used from files in %/tests
+::
+|%
+::  +expect-eq: compares :expected and :actual and pretty-prints the result
+::
+++  expect-eq
+  |=  [expected=vase actual=vase]
+  ^-  tang
+  ::
+  =|  result=tang
+  ::
+  =?  result  !=(q.expected q.actual)
+    %+  weld  result
+    ^-  tang
+    :~  [%palm [": " ~ ~ ~] [leaf+"expected" (sell expected) ~]]
+        [%palm [": " ~ ~ ~] [leaf+"actual  " (sell actual) ~]]
+    ==
+  ::
+  =?  result  !(~(nest ut p.actual) | p.expected)
+    %+  weld  result
+    ^-  tang
+    :~  :+  %palm  [": " ~ ~ ~]
+        :~  [%leaf "failed to nest"]
+            (~(dunk ut p.actual) %actual)
+            (~(dunk ut p.expected) %expected)
+    ==  ==
+  result
+::  +expect: compares :actual to %.y and pretty-prints anything else
+::
+++  expect
+  |=  actual=vase
+  (expect-eq !>(%.y) actual)
+::  +expect-fail: kicks a trap, expecting crash. pretty-prints if succeeds
+::
+++  expect-fail
+  |=  a=(trap)
+  ^-  tang
+  =/  b  (mule a)
+  ?-  -.b
+    %|  ~
+    %&  ['expected failure - succeeded' ~]
+  ==
+::  +expect-runs: kicks a trap, expecting success; returns trace on failure
+::
+++  expect-success
+  |=  a=(trap)
+  ^-  tang
+  =/  b  (mule a)
+  ?-  -.b
+    %&  ~
+    %|  ['expected success - failed' p.b]
+  ==
+::  $a-test-chain: a sequence of tests to be run
+::
+::  NB: arms shouldn't start with `test-` so that `-test % ~` runs
+::
++$  a-test-chain
+  $_
+  |?
+  ?:  =(0 0)
+    [%& p=*tang]
+  [%| p=[tang=*tang next=^?(..$)]]
+::  +run-chain: run a sequence of tests, stopping at first failure
+::
+++  run-chain
+  |=  seq=a-test-chain
+  ^-  tang
+  =/  res  $:seq
+  ?-  -.res
+    %&  p.res
+    %|  ?.  =(~ tang.p.res)
+          tang.p.res
+        $(seq next.p.res)
+  ==
+::  +category: prepends a name to an error result; passes successes unchanged
+::
+++  category
+  |=  [a=tape b=tang]  ^-  tang
+  ?:  =(~ b)  ~  :: test OK
+  :-  leaf+"in: '{a}'"
+  (turn b |=(c=tank rose+[~ "  " ~]^~[c]))
+--

--- a/desk/mar/json.hoon
+++ b/desk/mar/json.hoon
@@ -8,17 +8,17 @@
 =,  eyre
 =,  format
 =,  html
-|_  jon=json
+|_  jon=^json
 ::
 ++  grow                                                ::  convert to
   |%
   ++  mime  [/application/json (as-octs:mimes -:txt)]   ::  convert to %mime
-  ++  txt   [(crip (en-json jon))]~
+  ++  txt   [(en:json jon)]~
   --
 ++  grab
   |%                                                    ::  convert from
-  ++  mime  |=([p=mite q=octs] (fall (rush (@t q.q) apex:de-json) *json))
-  ++  noun  json                                        ::  clam from %noun
+  ++  mime  |=([p=mite q=octs] (fall (de:json (@t q.q)) *^json))
+  ++  noun  ^json                                        ::  clam from %noun
   ++  numb  numb:enjs
   ++  time  time:enjs
   --

--- a/desk/ted/test.hoon
+++ b/desk/ted/test.hoon
@@ -1,0 +1,139 @@
+/-  spider
+/+  strandio
+=,  strand=strand:spider
+=>
+|%
+::  $test: a test with a fully resolved path
+::  $test-arm: test with name (derived from its arm name in a test core)
+::  $test-func: single test, as gate; sample is entropy, produces failures
+::
++$  test       [=path func=test-func]
++$  test-arm   [name=term func=test-func]
++$  test-func  (trap tang)
+--
+=>
+|%
+::  +run-test: execute an individual test
+::
+++  run-test
+  |=  [pax=path test=test-func]
+  ^-  [ok=? =tang]
+  =+  name=(spud pax)
+  =+  run=(mule test)
+  ?-  -.run
+    %|  |+(welp p.run leaf+"CRASHED {name}" ~)
+    %&  ?:  =(~ p.run)
+          &+[leaf+"OK      {name}"]~
+        |+(flop `tang`[leaf+"FAILED  {name}" p.run])
+  ==
+::  +resolve-test-paths: add test names to file paths to form full identifiers
+::
+++  resolve-test-paths
+  |=  paths-to-tests=(map path (list test-arm))
+  ^-  (list test)
+  %-  sort  :_  |=([a=test b=test] !(aor path.a path.b))
+  ^-  (list test)
+  %-  zing
+  %+  turn  ~(tap by paths-to-tests)
+  |=  [=path test-arms=(list test-arm)]
+  ^-  (list test)
+  ::  for each test, add the test's name to :path
+  ::
+  %+  turn  test-arms
+  |=  =test-arm
+  ^-  test
+  [(weld path /[name.test-arm]) func.test-arm]
+::  +get-test-arms: convert test arms to functions and produce them
+::
+++  get-test-arms
+  |=  [typ=type cor=*]
+  ^-  (list test-arm)
+  =/  arms=(list @tas)  (sloe typ)
+  %+  turn  (skim arms has-test-prefix)
+  |=  name=term
+  ^-  test-arm
+  =/  fire-arm=nock
+    ~|  [%failed-to-compile-test-arm name]
+    q:(~(mint ut typ) p:!>(*tang) [%limb name])
+  [name |.(;;(tang ~>(%bout.[1 name] .*(cor fire-arm))))]
+::  +has-test-prefix: does the arm define a test we should run?
+::
+++  has-test-prefix
+  |=  a=term  ^-  ?
+  =((end [3 5] a) 'test-')
+::
+++  find-test-files
+  =|  fiz=(set [=beam test=(unit term)])
+  =/  m  (strand ,_fiz)
+  |=  bez=(list beam)
+  ^-  form:m
+  =*  loop  $
+  ?~  bez
+    (pure:m fiz)
+  ;<  hav=?  bind:m  (check-for-file:strandio -.i.bez (snoc s.i.bez %hoon))
+  ?:  hav
+    loop(bez t.bez, fiz (~(put in fiz) [i.bez(s (snoc s.i.bez %hoon)) ~]))
+  ;<  fez=(list path)  bind:m  (list-tree:strandio i.bez)
+  ?.  =(~ fez)
+    =/  foz
+      %+  murn  fez
+      |=  p=path
+      ?.  =(%hoon (rear p))  ~
+      (some [[-.i.bez p] ~])
+    loop(bez t.bez, fiz (~(gas in fiz) foz))
+  ::
+  ::  XX this logic appears to be vestigial
+  ::
+  =/  tex=term
+    ~|  bad-test-beam+i.bez
+    =-(?>(((sane %tas) -) -) (rear s.i.bez))
+  =/  xup=path  (snip s.i.bez)
+  ;<  hov=?  bind:m  (check-for-file:strandio i.bez(s (snoc xup %hoon)))
+  ?.  hov
+    ~|(no-tests-at-path+i.bez !!)
+  loop(bez t.bez, fiz (~(put in fiz) [[-.i.bez (snoc xup %hoon)] `tex]))
+--
+^-  thread:spider
+|=  arg=vase
+=/  m  (strand ,vase)
+^-  form:m
+;<  =bowl:strand  bind:m  get-bowl:strandio
+=/  paz=(list path)
+  :: if no args, test everything under /=base=/tests
+  ::
+  ?~  q.arg
+    ~[/(scot %p our.bowl)/[q.byk.bowl]/(scot %da now.bowl)/tests]
+  :: else cast path to ~[path] if needed
+  ::
+  ?@  +<.q.arg
+    [(tail !<([~ path] arg)) ~]
+  (tail !<([~ (list path)] arg))
+=/  bez=(list beam)
+  (turn paz |=(p=path ~|([%test-not-beam p] (need (de-beam p)))))
+;<  fiz=(set [=beam test=(unit term)])  bind:m  (find-test-files bez)
+=>  .(fiz (sort ~(tap in fiz) aor))
+=|  test-arms=(map path (list test-arm))
+=|  build-ok=?
+|-  ^-  form:m
+=*  gather-tests  $
+?^  fiz
+  ;<  cor=(unit vase)  bind:m  (build-file:strandio beam.i.fiz)
+  ?~  cor
+    ~>  %slog.0^leaf+"FAILED  {(spud s.beam.i.fiz)} (build)"
+    gather-tests(fiz t.fiz, build-ok |)
+  ~>  %slog.0^leaf+"built   {(spud s.beam.i.fiz)}"
+  =/  arms=(list test-arm)  (get-test-arms u.cor)
+  ::  if test path specified an arm prefix, filter arms to match
+  =?  arms  ?=(^ test.i.fiz)
+    %+  skim  arms
+    |=  test-arm
+    =((end [3 (met 3 u.test.i.fiz)] name) u.test.i.fiz)
+  =.  test-arms  (~(put by test-arms) (snip s.beam.i.fiz) arms)
+  gather-tests(fiz t.fiz)
+%-  pure:m  !>  ^=  ok
+%+  roll  (resolve-test-paths test-arms)
+|=  [[=path =test-func] ok=_build-ok]
+^+  ok
+=/  res  (run-test path test-func)
+%-  (slog (flop tang.res))
+&(ok ok.res)

--- a/desk/tests/test-etch.hoon
+++ b/desk/tests/test-etch.hoon
@@ -1,0 +1,91 @@
+/+  e=etch, *test
+|%
+++  test-atom
+  ::
+  ::  Given, input `x1`, which contains an integer
+  =/  x1=@ud  5
+  ::
+  ::  Input `x2`, which contains a string
+  =/  x2=@t  'five'
+  ::
+  ::  Input `x3`, which contains a loobean
+  =/  x3=?  %.y
+  ::
+  ::  And input `x4`, which is null
+  =/  x4  ~
+  ::
+  ::  When I run +en-vase:etch on these inputs
+  ;:  weld
+  %+  expect-eq
+  ::
+  ::  Then, the result for x1 should be a json number 5,
+    !>((need (de-json:html '5')))
+  !>((en-vase:e !>(x1)))
+  %+  expect-eq
+  ::
+  ::  the result for x2 should be a json string "five",
+    !>((need (de-json:html '"five"')))
+  !>((en-vase:e !>(x2)))
+  %+  expect-eq
+  ::
+  ::  and the result for x3 should be a json boolean 'true'
+    !>((need (de-json:html 'true')))
+  !>((en-vase:e !>(x3)))
+  %+  expect-eq
+  ::
+  ::  and the result for x4 should be null
+    !>(~)
+  !>((en-vase:e !>(x4)))
+  ==
+::
+++  test-list
+  ::
+  ::  Given, 
+  ::  An input `x1` containing a list of loobeans,
+  =/  x1=(list ?)  ~[%.y %.n %.y]
+  ::  An input `x2` containing a list of cords,
+  =/  x2=(list @t)  ~['fee' 'fi' 'fo']
+  ::  An input `x3` containing a list of integers,
+  =/  x3=(list @ud)  ~[1 2 3]
+  ::
+  ::  When I run +en-vase:etch on those lists
+  ;:  weld
+  %+  expect-eq
+  ::
+  ::  Then, the result for x1 should be a json array of true, false, true,
+    !>((need (de-json:html '[true, false, true]')))
+  !>((en-vase:e !>(x1)))
+  ::
+  ::  the result for x2 should be a json array of "fee", "fi", "fo",
+  %+  expect-eq
+    !>((need (de-json:html '["fee", "fi", "fo"]')))
+  !>((en-vase:e !>(x2)))
+  ::
+  ::  and the result for x2 should be a json array of 1,2,3
+  %+  expect-eq
+    !>((need (de-json:html '[1,2,3]')))
+  !>((en-vase:e !>(x3)))
+  ==
+::
+++  test-cell
+  ::
+  ::  Given, 
+  ::  An input `x1`,
+  =/  x1=[a=@ud b=@t]  [a=1 b='value']
+  ::
+  ::  Another input, `x2`
+  =/  x2=[a=@ud b=[@ud @ud @t]]  [a=1 b=[1 2 'last']]
+  ;:  weld
+  %+  expect-eq
+  ::
+  ::  Then, the result for x1 should be the `json` object below
+    !>((need (de-json:html '{"a": 1, "b": "value"}')))
+  !>((en-vase:e !>(x1)))
+  %+  expect-eq
+  ::
+  ::  Then, the result for x2 should be the `json` object below
+    !>((need (de-json:html '{"a": 1, "b": [1,2,"last"]}')))
+  !>((en-vase:e !>(x2)))
+  ==
+::
+--


### PR DESCRIPTION
Check +test-list to see what the behavior is with lists now.

```
++  test-list
  ::
  ::  Given, 
  ::  An input `x1` containing a list of loobeans,
  =/  x1=(list ?)  ~[%.y %.n %.y]
  ::  An input `x2` containing a list of cords,
  =/  x2=(list @t)  ~['fee' 'fi' 'fo']
  ::  An input `x3` containing a list of integers,
  =/  x3=(list @ud)  ~[1 2 3]
  ::
  ::  When I run +en-vase:etch on those lists
  ;:  weld
  %+  expect-eq
  ::
  ::  Then, the result for x1 should be a json array of true, false, true,
    !>((need (de-json:html '[true, false, true]')))
  !>((en-vase:e !>(x1)))
  ::
  ::  the result for x2 should be a json array of "fee", "fi", "fo",
  %+  expect-eq
    !>((need (de-json:html '["fee", "fi", "fo"]')))
  !>((en-vase:e !>(x2)))
  ::
  ::  and the result for x2 should be a json array of 1,2,3
  %+  expect-eq
    !>((need (de-json:html '[1,2,3]')))
  !>((en-vase:e !>(x3)))
  ==
```

This is the test result when you run the test above without the fix:
```
FAILED  /tests/test-etch/test-list
expected: [%a p=[i=[%s p='fee'] t=[i=[%s p='fi'] t=~[[%s p='fo']]]]]
actual  : [%a p=[i=[%s p='fee'] t=[i=[%a p=[i=[%s p='fi'] t=[i=[%a p=[i=[%s p='fo'] t=[i=~ t=~]]] t=~]]] t=~]]]
```